### PR TITLE
run-qemu.sh: support --release (signed GitHub Releases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,19 @@ Outputs land in `build/tmp/deploy/images/<machine>/`.
 A helper script is included: [`scripts/run-qemu.sh`](scripts/run-qemu.sh).
 
 ```bash
-# Pulls the latest CI-built image and boots it
-./scripts/run-qemu.sh --fetch
-
-# Or, if you already have an artifact (or a local build)
+# Boot a local build, or whatever's already in the cache
 ./scripts/run-qemu.sh
 
-# Pick a specific GitHub Actions run
+# Pull the latest published release (verifies sha256 + decompresses)
+./scripts/run-qemu.sh --release
+
+# Pick a specific release tag
+./scripts/run-qemu.sh --release v1-alpha
+
+# Pull the latest CI artifact instead (unreleased, last 7 days)
+./scripts/run-qemu.sh --fetch
+
+# Or a specific GitHub Actions run
 ./scripts/run-qemu.sh --fetch 24543210987
 ```
 

--- a/scripts/run-qemu.sh
+++ b/scripts/run-qemu.sh
@@ -8,6 +8,8 @@
 #   scripts/run-qemu.sh                      boot image from local build or cache
 #   scripts/run-qemu.sh --fetch              pull the latest CI artifact first
 #   scripts/run-qemu.sh --fetch <run-id>     pull a specific GitHub Actions run
+#   scripts/run-qemu.sh --release            pull the latest published release
+#   scripts/run-qemu.sh --release <tag>      pull a specific release (e.g. v1-alpha)
 #   scripts/run-qemu.sh -h | --help          this help
 #
 # Environment overrides:
@@ -16,8 +18,9 @@
 #   CPUS=2           guest CPU count (default 2)
 #
 # Image discovery order:
-#   1. local Yocto build: build/tmp/deploy/images/qemux86-64/*.rootfs.wic
-#   2. CI artifact cache: build/qemu-cache/yocto-image-qemux86-64/*.rootfs.wic
+#   1. local Yocto build:  build/tmp/deploy/images/qemux86-64/*.rootfs.wic
+#   2. CI artifact cache:  build/qemu-cache/yocto-image-qemux86-64/*.rootfs.wic
+#   3. Release cache:      build/qemu-cache/release-<tag>/oe5xrx-qemux86-64-<tag>.wic
 #
 # A/B boot testing (from inside the guest):
 #   grub-editenv /boot/EFI/BOOT/grubenv list
@@ -36,12 +39,14 @@ set -euo pipefail
 
 REPO="OE5XRX/linux-image"
 ARTIFACT_NAME="yocto-image-qemux86-64"
+RELEASE_ASSET_GLOB="oe5xrx-qemux86-64-*"
 
 # Resolve the repo root (script lives at <repo>/scripts/).
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # build/ is .gitignored — stash QEMU state there to keep the tree clean.
 CACHE_DIR="${REPO_ROOT}/build/qemu-cache"
 ARTIFACT_DIR="${CACHE_DIR}/${ARTIFACT_NAME}"
+RELEASE_DIR=""   # set by fetch_release; also searched when locating the wic
 
 SSH_PORT="${SSH_PORT:-2222}"
 MEM="${MEM:-1024}"
@@ -69,6 +74,42 @@ fetch_artifact() {
     gh run download "${run_id}" -R "${REPO}" -n "${ARTIFACT_NAME}" -D "${ARTIFACT_DIR}"
 }
 
+fetch_release() {
+    local tag="${1:-}"
+    if [ -z "${tag}" ]; then
+        echo "==> Finding latest release on ${REPO}..."
+        tag=$(gh release list -R "${REPO}" --limit 1 \
+            --json tagName --jq '.[0].tagName // empty')
+    fi
+    [ -n "${tag}" ] || { echo "ERROR: no release found" >&2; exit 1; }
+
+    RELEASE_DIR="${CACHE_DIR}/release-${tag}"
+    mkdir -p "${RELEASE_DIR}"
+
+    echo "==> Downloading release ${tag} (qemux86-64 assets)..."
+    gh release download "${tag}" -R "${REPO}" \
+        --pattern "${RELEASE_ASSET_GLOB}.wic.bz2" \
+        --pattern "${RELEASE_ASSET_GLOB}.wic.bz2.sha256" \
+        -D "${RELEASE_DIR}" --clobber
+
+    local bz2
+    bz2=$(find "${RELEASE_DIR}" -maxdepth 1 -name '*.wic.bz2' -print -quit)
+    [ -n "${bz2}" ] || { echo "ERROR: release ${tag} has no qemux86-64 wic asset" >&2; exit 1; }
+
+    # Verify checksum if the sidecar is there — cheap integrity check.
+    local sha="${bz2}.sha256"
+    if [ -f "${sha}" ]; then
+        echo "==> Verifying sha256..."
+        (cd "${RELEASE_DIR}" && sha256sum -c "$(basename "${sha}")")
+    fi
+
+    # Decompress once; keep the archive so we don't re-download next run.
+    if [ ! -f "${bz2%.bz2}" ]; then
+        echo "==> Decompressing $(basename "${bz2}")..."
+        bzip2 -dk "${bz2}"
+    fi
+}
+
 # --- Arg parsing ---
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -81,30 +122,45 @@ while [ $# -gt 0 ]; do
                 shift
             fi
             ;;
+        --release)
+            # Optional positional tag; anything starting with '-' is another flag.
+            if [ -n "${2:-}" ] && [[ "${2}" != -* ]]; then
+                fetch_release "${2}"
+                shift 2
+            else
+                fetch_release ""
+                shift
+            fi
+            ;;
         -h|--help) usage 0 ;;
         *) echo "Unknown arg: $1" >&2; usage 2 ;;
     esac
 done
 
 # --- Locate the wic ---
+# Accept both the Yocto-native name (*.rootfs.wic, from local builds and CI
+# artifacts) and the release-asset name (oe5xrx-qemux86-64-<tag>.wic).
 WIC=""
 for search_dir in \
     "${REPO_ROOT}/build/tmp/deploy/images/qemux86-64" \
-    "${ARTIFACT_DIR}"; do
-    [ -d "${search_dir}" ] || continue
-    WIC=$(find "${search_dir}" -maxdepth 2 -name '*.rootfs.wic' -print -quit 2>/dev/null || true)
+    "${ARTIFACT_DIR}" \
+    "${RELEASE_DIR}"; do
+    [ -n "${search_dir}" ] && [ -d "${search_dir}" ] || continue
+    WIC=$(find "${search_dir}" -maxdepth 2 \
+        \( -name '*.rootfs.wic' -o -name 'oe5xrx-qemux86-64-*.wic' \) \
+        -not -name '*.bz2' -not -name '*.xz' -not -name '*.gz' \
+        -print -quit 2>/dev/null || true)
     [ -n "${WIC}" ] && break
 done
 
 if [ -z "${WIC}" ]; then
     cat >&2 <<EOF
-ERROR: no *.rootfs.wic found.
+ERROR: no qemux86-64 wic found.
 
-Either build locally with:
-    kas build qemux86-64.yml
-
-Or pull the latest CI artifact:
-    $0 --fetch
+Options:
+    kas build qemux86-64.yml       build it locally
+    $0 --fetch                     pull the latest CI artifact
+    $0 --release                   pull the latest published release
 EOF
     exit 1
 fi


### PR DESCRIPTION
## What / Why

The helper script previously only knew about CI workflow artifacts
(`--fetch`), which expire after 7 days. Once we started publishing
signed releases, the natural "fetch the image and boot it" flow
stopped working.

## Changes

- `--release` — download the latest published release's qemux86-64 asset
- `--release <tag>` — pin to a specific tag, e.g. `v1-alpha`
- Verifies `.sha256` sidecar before decompressing
- Keeps `.wic.bz2` around so a re-run doesn't re-download
- Widened wic locator to accept the release naming
  (`oe5xrx-qemux86-64-*.wic`) alongside `*.rootfs.wic`

## Testing

- `bash -n` + shellcheck clean (existing SC2086 on `CPU_FLAGS` is
  intentional — qemu consumes them as separate args)
- End-to-end dry-run against `v1-alpha`: found release, pulled both
  assets, sha256 verified OK, decompression started correctly

## Breaking changes

None. `--fetch` and the zero-arg (local build / cache) paths are
untouched.