### PR TITLE
ab-layout: rename /etc/station-agent -> /etc/stationagent

### DIFF
--- a/meta-oe5xrx-remotestation/recipes-core/ab-layout/ab-layout_1.0.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/ab-layout/ab-layout_1.0.bb
@@ -10,7 +10,7 @@ SRC_URI = " \
     file://var.mount \
     file://home.mount \
     file://root.mount \
-    file://etc-station-agent.mount \
+    file://etc-stationagent.mount \
     file://data-init.service \
     file://data-init.sh \
 "
@@ -24,7 +24,7 @@ SYSTEMD_SERVICE:${PN} = " \
     var.mount \
     home.mount \
     root.mount \
-    etc-station-agent.mount \
+    etc-stationagent.mount \
     data-init.service \
 "
 # boot-firmware.mount is NOT listed here — we install it to /etc/ and wire the
@@ -42,7 +42,7 @@ do_install() {
     install -m 0644 ${WORKDIR}/var.mount           ${D}${systemd_system_unitdir}/
     install -m 0644 ${WORKDIR}/home.mount          ${D}${systemd_system_unitdir}/
     install -m 0644 ${WORKDIR}/root.mount          ${D}${systemd_system_unitdir}/
-    install -m 0644 ${WORKDIR}/etc-station-agent.mount ${D}${systemd_system_unitdir}/
+    install -m 0644 ${WORKDIR}/etc-stationagent.mount ${D}${systemd_system_unitdir}/
     install -m 0644 ${WORKDIR}/data-init.service   ${D}${systemd_system_unitdir}/
 
     install -d ${D}${sysconfdir}/systemd/system

--- a/meta-oe5xrx-remotestation/recipes-core/ab-layout/files/data-init.sh
+++ b/meta-oe5xrx-remotestation/recipes-core/ab-layout/files/data-init.sh
@@ -30,15 +30,19 @@ chmod 0700 "${DATA}/root"
 chown 0:0 "${DATA}/root"
 chmod 0755 "${DATA}/etc-overlay/upper" "${DATA}/etc-overlay/work"
 
-# /etc/station-agent — bind-mount target for the station-agent config dir.
+# /etc/stationagent — bind-mount target for the station-agent config dir.
+# (Named "stationagent" without a hyphen because systemd mount-unit file
+# names must match the mount path and dashes in paths need to be escaped
+# as \x2d — a readability footgun we avoid by not having a dash here.)
+#
 # On first boot, seed from the shipped default (from the read-only rootfs)
 # if the overlay copy is empty. Later boots keep whatever the operator
 # (or provisioning flow) has written.
-AGENT_ETC="${DATA}/etc-overlay/station-agent"
+AGENT_ETC="${DATA}/etc-overlay/stationagent"
 mkdir -p "${AGENT_ETC}"
 chmod 0755 "${AGENT_ETC}"
-if [ ! -f "${AGENT_ETC}/config.yml" ] && [ -f /etc/station-agent/config.yml ]; then
-    cp /etc/station-agent/config.yml "${AGENT_ETC}/config.yml"
+if [ ! -f "${AGENT_ETC}/config.yml" ] && [ -f /etc/stationagent/config.yml ]; then
+    cp /etc/stationagent/config.yml "${AGENT_ETC}/config.yml"
     chmod 0600 "${AGENT_ETC}/config.yml"
 fi
 

--- a/meta-oe5xrx-remotestation/recipes-core/ab-layout/files/etc-stationagent.mount
+++ b/meta-oe5xrx-remotestation/recipes-core/ab-layout/files/etc-stationagent.mount
@@ -1,5 +1,5 @@
 [Unit]
-Description=Bind /etc/station-agent to persistent data partition
+Description=Bind /etc/stationagent to persistent data partition
 Requires=mnt-data.mount data-init.service
 After=mnt-data.mount data-init.service
 Before=local-fs.target station-agent.service umount.target
@@ -7,8 +7,8 @@ DefaultDependencies=no
 Conflicts=umount.target
 
 [Mount]
-What=/mnt/data/etc-overlay/station-agent
-Where=/etc/station-agent
+What=/mnt/data/etc-overlay/stationagent
+Where=/etc/stationagent
 Type=none
 Options=bind
 

--- a/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
@@ -54,7 +54,7 @@ WKS_FILE:raspberrypi4-64 = "oe5xrx-remotestation-ab.wks.in"
 # ---- Station agent dirs ---------------------------------------------------
 
 create_agent_dirs() {
-    install -d ${IMAGE_ROOTFS}/etc/station-agent
+    install -d ${IMAGE_ROOTFS}/etc/stationagent
 }
 ROOTFS_POSTPROCESS_COMMAND += "create_agent_dirs;"
 

--- a/meta-oe5xrx-remotestation/recipes-core/station-agent/files/config.yml
+++ b/meta-oe5xrx-remotestation/recipes-core/station-agent/files/config.yml
@@ -7,7 +7,7 @@ server_url: https://ham.oe5xrx.org
 
 # Authentication: Ed25519 signature (required)
 # station_id: 1
-# ed25519_key_path: /etc/station-agent/device_key.pem
+# ed25519_key_path: /etc/stationagent/device_key.pem
 
 heartbeat_interval: 60
 ota_check_interval: 5

--- a/meta-oe5xrx-remotestation/recipes-core/station-agent/files/station-agent.service
+++ b/meta-oe5xrx-remotestation/recipes-core/station-agent/files/station-agent.service
@@ -10,7 +10,7 @@ WorkingDirectory=/var/lib/station-agent
 Restart=on-failure
 RestartSec=10
 User=root
-Environment=STATION_AGENT_CONFIG=/etc/station-agent/config.yml
+Environment=STATION_AGENT_CONFIG=/etc/stationagent/config.yml
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
@@ -31,9 +31,11 @@ do_install:append() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/station-agent.service ${D}${systemd_system_unitdir}/
 
-    # Default config (operator-editable)
-    install -d ${D}${sysconfdir}/station-agent
-    install -m 0600 ${WORKDIR}/config.yml ${D}${sysconfdir}/station-agent/config.yml
+    # Default config (operator-editable). Directory name is "stationagent"
+    # without a dash so the etc-stationagent.mount unit doesn't need the
+    # systemd \x2d path escape.
+    install -d ${D}${sysconfdir}/stationagent
+    install -m 0600 ${WORKDIR}/config.yml ${D}${sysconfdir}/stationagent/config.yml
 }
 
-CONFFILES:${PN} = "${sysconfdir}/station-agent/config.yml"
+CONFFILES:${PN} = "${sysconfdir}/stationagent/config.yml"


### PR DESCRIPTION
## What / Why

The bind-mount unit for the station-agent config dir was named `etc-station-agent.mount`. Systemd mount-unit filenames must match their mount path with slashes replaced by dashes **and existing dashes escaped as `\x2d`**. Our filename didn't escape the dash, so systemd parsed it as `/etc/station/agent` (three levels), which conflicted with `Where=/etc/station-agent` and was rejected as "bad unit file setting". The bind-mount never fired → the station-agent on every provisioned VM read the shipped default config.yml instead of the per-station one written to the data partition at provisioning time.

## Fix

Rename the config dir path from `/etc/station-agent` to `/etc/stationagent`. No dash = no escape. The unit file is now `etc-stationagent.mount` and systemd loads it cleanly.

Service name `station-agent.service`, package name, and `/var/lib/station-agent/` are unchanged — they're not mount-unit filenames and the dash there is fine.

## Files touched

- `recipes-core/ab-layout/files/etc-station-agent.mount` → `etc-stationagent.mount` (renamed + `Where` / `What` updated)
- `ab-layout_1.0.bb` — 3 references updated
- `data-init.sh` — overlay + seed paths
- `images/oe5xrx-remotestation-image.bb` — `create_agent_dirs` target
- `station-agent_0.1.0.bb` — install + CONFFILES path
- `station-agent.service` — `STATION_AGENT_CONFIG` env
- `config.yml` — commented `ed25519_key_path` example

## Downstream

A matching change in station-manager updates `config_render` + `guestfish` to inject at `/etc/stationagent/`. The two must ship together — old images + new station-manager (or vice versa) would silently put the config in the wrong place.

## Testing

`kas dump` clean, shellcheck/yamllint via CI. Real test is a new release build + boot in QEMU/Proxmox showing the mount unit active and the provisioned config actually used.