### PR TITLE
image: stamp release tag into /etc/issue + /etc/os-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
           - qemux86-64
           - raspberrypi4-64
         default: qemux86-64
+      release_tag:
+        description: "Release tag for /etc/issue + /etc/os-release stamp (empty -> dev)"
+        type: string
+        default: ""
   workflow_call:
     inputs:
       machine:
@@ -33,9 +37,6 @@ concurrency:
 env:
   KAS_MACHINE: ${{ inputs.machine }}
   OE5XRX_RELEASE_TAG: ${{ inputs.release_tag || 'dev' }}
-  # bitbake sanitizes its environment; tell it to let our release-tag var
-  # through. The image recipe reads it in a ROOTFS_POSTPROCESS_COMMAND.
-  BB_ENV_PASSTHROUGH_ADDITIONS: OE5XRX_RELEASE_TAG
   CACHE_VOLUME_NAME: oe5xrx-yocto-cache
 
 jobs:
@@ -220,6 +221,12 @@ jobs:
 
       - name: Build with Kas
         run: |
+          # bitbake sanitizes its environment; extend the passthrough list
+          # with our release-tag var, preserving anything the runner may
+          # already have set (belt-and-braces: OE5XRX_RELEASE_TAG is also
+          # declared in oe5xrx.yml's local_conf_header).
+          export BB_ENV_PASSTHROUGH_ADDITIONS="${BB_ENV_PASSTHROUGH_ADDITIONS:+$BB_ENV_PASSTHROUGH_ADDITIONS }OE5XRX_RELEASE_TAG"
+
           if [ "${KAS_MACHINE}" = "qemux86-64" ]; then
             kas build qemux86-64.yml
           elif [ "${KAS_MACHINE}" = "raspberrypi4-64" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ on:
         description: "Target machine"
         type: string
         required: true
+      release_tag:
+        description: "Release tag for /etc/issue + /etc/os-release stamp (empty -> dev)"
+        type: string
+        default: ""
 
 concurrency:
   # Serialize across all callers — the Hetzner cache volume can only be
@@ -28,6 +32,10 @@ concurrency:
 
 env:
   KAS_MACHINE: ${{ inputs.machine }}
+  OE5XRX_RELEASE_TAG: ${{ inputs.release_tag || 'dev' }}
+  # bitbake sanitizes its environment; tell it to let our release-tag var
+  # through. The image recipe reads it in a ROOTFS_POSTPROCESS_COMMAND.
+  BB_ENV_PASSTHROUGH_ADDITIONS: OE5XRX_RELEASE_TAG
   CACHE_VOLUME_NAME: oe5xrx-yocto-cache
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       machine: qemux86-64
+      release_tag: ${{ github.ref_name }}
     secrets: inherit
 
   build-rpi:
@@ -31,6 +32,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       machine: raspberrypi4-64
+      release_tag: ${{ github.ref_name }}
     secrets: inherit
 
   release:

--- a/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
@@ -75,6 +75,10 @@ python stamp_release() {
 
     rootfs = d.getVar('IMAGE_ROOTFS')
     tag = d.getVar('OE5XRX_RELEASE_TAG') or 'dev'
+    # Escape for inclusion inside double-quoted os-release values.
+    # Release tags in practice contain only [A-Za-z0-9._-], but a stray
+    # quote would generate an unparseable /etc/os-release.
+    quoted_tag = tag.replace('\\', '\\\\').replace('"', '\\"')
 
     etc_dir = os.path.join(rootfs, 'etc')
     os.makedirs(etc_dir, exist_ok=True)
@@ -93,10 +97,10 @@ python stamp_release() {
         return
 
     overrides = {
-        'PRETTY_NAME': f'OE5XRX Remote Station {tag}',
-        'VERSION': tag,
-        'VERSION_ID': tag,
-        'OE5XRX_RELEASE': tag,
+        'PRETTY_NAME': f'OE5XRX Remote Station {quoted_tag}',
+        'VERSION': quoted_tag,
+        'VERSION_ID': quoted_tag,
+        'OE5XRX_RELEASE': quoted_tag,
     }
 
     with open(os_release) as f:

--- a/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
@@ -58,6 +58,36 @@ create_agent_dirs() {
 }
 ROOTFS_POSTPROCESS_COMMAND += "create_agent_dirs;"
 
+# ---- Release branding -----------------------------------------------------
+# OE5XRX_RELEASE_TAG comes from the release workflow (e.g. "v1-beta") via
+# BB_ENV_PASSTHROUGH_ADDITIONS in oe5xrx.yml, or defaults to "dev" for local
+# builds. The station agent reads PRETTY_NAME from /etc/os-release for its
+# heartbeat's os_version field, so replacing the Yocto/Poky defaults here
+# surfaces the release in the web UI.
+OE5XRX_RELEASE_TAG ??= "dev"
+
+stamp_release() {
+    install -d ${IMAGE_ROOTFS}/etc
+
+    cat > ${IMAGE_ROOTFS}/etc/issue <<EOF
+OE5XRX Remote Station ${OE5XRX_RELEASE_TAG}
+Kernel \r on an \m (\l)
+
+EOF
+
+    if [ -f ${IMAGE_ROOTFS}/etc/os-release ]; then
+        sed -i \
+            -e 's|^PRETTY_NAME=.*|PRETTY_NAME="OE5XRX Remote Station ${OE5XRX_RELEASE_TAG}"|' \
+            -e 's|^VERSION=.*|VERSION="${OE5XRX_RELEASE_TAG}"|' \
+            -e 's|^VERSION_ID=.*|VERSION_ID="${OE5XRX_RELEASE_TAG}"|' \
+            ${IMAGE_ROOTFS}/etc/os-release
+        # Additional field for consumers that want the raw tag without the
+        # "OE5XRX Remote Station " prefix stripping ceremony.
+        echo 'OE5XRX_RELEASE="${OE5XRX_RELEASE_TAG}"' >> ${IMAGE_ROOTFS}/etc/os-release
+    fi
+}
+ROOTFS_POSTPROCESS_COMMAND += "stamp_release;"
+
 # fstab fix for RPi: rewrite /dev/mmcblk0p1 -> PARTLABEL=firmware.
 # (Belt-and-suspenders alongside the boot-firmware.mount override in ab-layout.)
 python fix_firmware_fstab() {

--- a/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
@@ -67,18 +67,26 @@ ROOTFS_POSTPROCESS_COMMAND += "create_agent_dirs;"
 OE5XRX_RELEASE_TAG ??= "dev"
 
 python stamp_release() {
-    # Python so we don't have to worry about sed-special chars in the
-    # tag (tags come from git refs — reasonably constrained, but still),
-    # and so rewriting an existing OE5XRX_RELEASE line on a rebuild is
-    # trivial instead of risking duplicate keys in /etc/os-release.
+    # Python so we don't have to worry about shell quoting at all — we
+    # just write the file directly. Also handles idempotent rewrite of
+    # /etc/os-release on incremental rebuilds (no appended duplicates).
     import os
+    import re
 
     rootfs = d.getVar('IMAGE_ROOTFS')
     tag = d.getVar('OE5XRX_RELEASE_TAG') or 'dev'
-    # Escape for inclusion inside double-quoted os-release values.
-    # Release tags in practice contain only [A-Za-z0-9._-], but a stray
-    # quote would generate an unparseable /etc/os-release.
-    quoted_tag = tag.replace('\\', '\\\\').replace('"', '\\"')
+
+    # Reject anything that isn't a plain release tag. Our tags come from
+    # `git tag vX.Y.Z` pushed into github.ref_name — disciplined input.
+    # Blocking everything outside this charset means downstream code
+    # (os-release parsers, shells that source it, /etc/issue, the
+    # station-agent's heartbeat) never has to reason about escaping:
+    # no quotes, no backslashes, no $, no backticks, no newlines.
+    if not re.fullmatch(r'[A-Za-z0-9._-]+', tag):
+        bb.fatal(
+            f"OE5XRX_RELEASE_TAG={tag!r} contains characters outside "
+            "[A-Za-z0-9._-]; pick a cleaner git tag."
+        )
 
     etc_dir = os.path.join(rootfs, 'etc')
     os.makedirs(etc_dir, exist_ok=True)
@@ -97,10 +105,10 @@ python stamp_release() {
         return
 
     overrides = {
-        'PRETTY_NAME': f'OE5XRX Remote Station {quoted_tag}',
-        'VERSION': quoted_tag,
-        'VERSION_ID': quoted_tag,
-        'OE5XRX_RELEASE': quoted_tag,
+        'PRETTY_NAME': f'OE5XRX Remote Station {tag}',
+        'VERSION': tag,
+        'VERSION_ID': tag,
+        'OE5XRX_RELEASE': tag,
     }
 
     with open(os_release) as f:

--- a/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
@@ -69,21 +69,29 @@ OE5XRX_RELEASE_TAG ??= "dev"
 stamp_release() {
     install -d ${IMAGE_ROOTFS}/etc
 
-    cat > ${IMAGE_ROOTFS}/etc/issue <<EOF
-OE5XRX Remote Station ${OE5XRX_RELEASE_TAG}
+    # Bitbake expands ${OE5XRX_RELEASE_TAG} at recipe-parse time before
+    # handing this function to /bin/sh, so quoting-vs-expansion is a
+    # non-issue. Landing the tag in a shell variable up-front makes that
+    # explicit (readers don't have to reason about which ${} is bitbake
+    # and which is shell) and lets us pick a pipe-safe sed delimiter.
+    TAG="${OE5XRX_RELEASE_TAG}"
+    ROOTFS="${IMAGE_ROOTFS}"
+
+    cat > "${ROOTFS}/etc/issue" <<EOF
+OE5XRX Remote Station ${TAG}
 Kernel \r on an \m (\l)
 
 EOF
 
-    if [ -f ${IMAGE_ROOTFS}/etc/os-release ]; then
+    if [ -f "${ROOTFS}/etc/os-release" ]; then
         sed -i \
-            -e 's|^PRETTY_NAME=.*|PRETTY_NAME="OE5XRX Remote Station ${OE5XRX_RELEASE_TAG}"|' \
-            -e 's|^VERSION=.*|VERSION="${OE5XRX_RELEASE_TAG}"|' \
-            -e 's|^VERSION_ID=.*|VERSION_ID="${OE5XRX_RELEASE_TAG}"|' \
-            ${IMAGE_ROOTFS}/etc/os-release
-        # Additional field for consumers that want the raw tag without the
-        # "OE5XRX Remote Station " prefix stripping ceremony.
-        echo 'OE5XRX_RELEASE="${OE5XRX_RELEASE_TAG}"' >> ${IMAGE_ROOTFS}/etc/os-release
+            -e "s|^PRETTY_NAME=.*|PRETTY_NAME=\"OE5XRX Remote Station ${TAG}\"|" \
+            -e "s|^VERSION=.*|VERSION=\"${TAG}\"|" \
+            -e "s|^VERSION_ID=.*|VERSION_ID=\"${TAG}\"|" \
+            "${ROOTFS}/etc/os-release"
+        # Additional field for consumers that want the raw tag without
+        # the "OE5XRX Remote Station " prefix stripping ceremony.
+        echo "OE5XRX_RELEASE=\"${TAG}\"" >> "${ROOTFS}/etc/os-release"
     fi
 }
 ROOTFS_POSTPROCESS_COMMAND += "stamp_release;"

--- a/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
@@ -66,33 +66,61 @@ ROOTFS_POSTPROCESS_COMMAND += "create_agent_dirs;"
 # surfaces the release in the web UI.
 OE5XRX_RELEASE_TAG ??= "dev"
 
-stamp_release() {
-    install -d ${IMAGE_ROOTFS}/etc
+python stamp_release() {
+    # Python so we don't have to worry about sed-special chars in the
+    # tag (tags come from git refs — reasonably constrained, but still),
+    # and so rewriting an existing OE5XRX_RELEASE line on a rebuild is
+    # trivial instead of risking duplicate keys in /etc/os-release.
+    import os
 
-    # Bitbake expands ${OE5XRX_RELEASE_TAG} at recipe-parse time before
-    # handing this function to /bin/sh, so quoting-vs-expansion is a
-    # non-issue. Landing the tag in a shell variable up-front makes that
-    # explicit (readers don't have to reason about which ${} is bitbake
-    # and which is shell) and lets us pick a pipe-safe sed delimiter.
-    TAG="${OE5XRX_RELEASE_TAG}"
-    ROOTFS="${IMAGE_ROOTFS}"
+    rootfs = d.getVar('IMAGE_ROOTFS')
+    tag = d.getVar('OE5XRX_RELEASE_TAG') or 'dev'
 
-    cat > "${ROOTFS}/etc/issue" <<EOF
-OE5XRX Remote Station ${TAG}
-Kernel \r on an \m (\l)
+    etc_dir = os.path.join(rootfs, 'etc')
+    os.makedirs(etc_dir, exist_ok=True)
 
-EOF
+    # /etc/issue — console banner. \r, \m, \l are getty escape codes for
+    # kernel release / machine / terminal line. Kept as literal
+    # backslash-letter pairs for getty to expand at login time.
+    with open(os.path.join(etc_dir, 'issue'), 'w') as f:
+        f.write(f"OE5XRX Remote Station {tag}\n")
+        f.write("Kernel \\r on an \\m (\\l)\n\n")
 
-    if [ -f "${ROOTFS}/etc/os-release" ]; then
-        sed -i \
-            -e "s|^PRETTY_NAME=.*|PRETTY_NAME=\"OE5XRX Remote Station ${TAG}\"|" \
-            -e "s|^VERSION=.*|VERSION=\"${TAG}\"|" \
-            -e "s|^VERSION_ID=.*|VERSION_ID=\"${TAG}\"|" \
-            "${ROOTFS}/etc/os-release"
-        # Additional field for consumers that want the raw tag without
-        # the "OE5XRX Remote Station " prefix stripping ceremony.
-        echo "OE5XRX_RELEASE=\"${TAG}\"" >> "${ROOTFS}/etc/os-release"
-    fi
+    # /etc/os-release — replace Poky defaults in-place, then ensure the
+    # OE5XRX_RELEASE field is set exactly once.
+    os_release = os.path.join(etc_dir, 'os-release')
+    if not os.path.exists(os_release):
+        return
+
+    overrides = {
+        'PRETTY_NAME': f'OE5XRX Remote Station {tag}',
+        'VERSION': tag,
+        'VERSION_ID': tag,
+        'OE5XRX_RELEASE': tag,
+    }
+
+    with open(os_release) as f:
+        lines = f.readlines()
+
+    seen = set()
+    out = []
+    for line in lines:
+        replaced = False
+        for key, value in overrides.items():
+            if line.startswith(key + '='):
+                out.append(f'{key}="{value}"\n')
+                seen.add(key)
+                replaced = True
+                break
+        if not replaced:
+            out.append(line)
+
+    for key, value in overrides.items():
+        if key not in seen:
+            out.append(f'{key}="{value}"\n')
+
+    with open(os_release, 'w') as f:
+        f.writelines(out)
 }
 ROOTFS_POSTPROCESS_COMMAND += "stamp_release;"
 

--- a/oe5xrx.yml
+++ b/oe5xrx.yml
@@ -33,6 +33,12 @@ local_conf_header:
     # Falls back to build/ local dirs if the mount doesn't exist (local dev).
     DL_DIR ?= "${@'/mnt/yocto-cache/downloads' if os.path.isdir('/mnt/yocto-cache') else '${TOPDIR}/downloads'}"
     SSTATE_DIR ?= "${@'/mnt/yocto-cache/sstate-cache' if os.path.isdir('/mnt/yocto-cache') else '${TOPDIR}/sstate-cache'}"
+    # Pass the release tag through to the rootfs stamp (consumed by the
+    # image recipe's postprocess — writes /etc/issue and /etc/os-release).
+    # release.yml -> build.yml -> kas sets OE5XRX_RELEASE_TAG from the
+    # pushed tag; local `kas build` defaults to "dev".
+    BB_ENV_PASSTHROUGH_ADDITIONS:append = " OE5XRX_RELEASE_TAG"
+    OE5XRX_RELEASE_TAG ??= "dev"
 
 target:
   - oe5xrx-remotestation-image


### PR DESCRIPTION
Fleet operators need to see which release a station is running at a glance — the current setup has every station reporting `Poky (Yocto Project Reference Distro) 5.0.11 scarthgap` regardless of actual release.

Pipe `github.ref_name` through `release.yml` → `build.yml` → bitbake as `OE5XRX_RELEASE_TAG`, then in `ROOTFS_POSTPROCESS_COMMAND` rewrite three fields in `/etc/os-release` (`PRETTY_NAME`, `VERSION`, `VERSION_ID`) and replace `/etc/issue` with the OE5XRX banner.

The station-agent heartbeat reads `PRETTY_NAME` and sends it back as `os_version`, so the station-manager dashboard will show "OE5XRX Remote Station v1-beta" etc. station-manager#20 displays this in the UI.

Local `kas build` defaults to `OE5XRX_RELEASE_TAG=dev`.

## Testing

- `yaml.safe_load` on all three changed YAML files → OK.
- Real test: tag a new release after merge, boot the resulting VM, `cat /etc/issue` + `cat /etc/os-release | grep PRETTY_NAME`.