### PR TITLE
kas: forward release tag via env: block

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,12 +221,9 @@ jobs:
 
       - name: Build with Kas
         run: |
-          # bitbake sanitizes its environment; extend the passthrough list
-          # with our release-tag var, preserving anything the runner may
-          # already have set (belt-and-braces: OE5XRX_RELEASE_TAG is also
-          # declared in oe5xrx.yml's local_conf_header).
-          export BB_ENV_PASSTHROUGH_ADDITIONS="${BB_ENV_PASSTHROUGH_ADDITIONS:+$BB_ENV_PASSTHROUGH_ADDITIONS }OE5XRX_RELEASE_TAG"
-
+          # OE5XRX_RELEASE_TAG is listed in oe5xrx.yml's `env:` block, so
+          # kas picks it up from this workflow's environment and forwards
+          # it into bitbake. No BB_ENV_PASSTHROUGH_ADDITIONS dance needed.
           if [ "${KAS_MACHINE}" = "qemux86-64" ]; then
             kas build qemux86-64.yml
           elif [ "${KAS_MACHINE}" = "raspberrypi4-64" ]; then

--- a/oe5xrx.yml
+++ b/oe5xrx.yml
@@ -33,12 +33,16 @@ local_conf_header:
     # Falls back to build/ local dirs if the mount doesn't exist (local dev).
     DL_DIR ?= "${@'/mnt/yocto-cache/downloads' if os.path.isdir('/mnt/yocto-cache') else '${TOPDIR}/downloads'}"
     SSTATE_DIR ?= "${@'/mnt/yocto-cache/sstate-cache' if os.path.isdir('/mnt/yocto-cache') else '${TOPDIR}/sstate-cache'}"
-    # Pass the release tag through to the rootfs stamp (consumed by the
-    # image recipe's postprocess — writes /etc/issue and /etc/os-release).
-    # release.yml -> build.yml -> kas sets OE5XRX_RELEASE_TAG from the
-    # pushed tag; local `kas build` defaults to "dev".
-    BB_ENV_PASSTHROUGH_ADDITIONS:append = " OE5XRX_RELEASE_TAG"
-    OE5XRX_RELEASE_TAG ??= "dev"
+
+# Environment variables kas forwards into the bitbake invocation. kas
+# scrubs the shell env by default, so setting OE5XRX_RELEASE_TAG at the
+# workflow level alone does nothing — it has to be listed here.
+#
+# Format: `NAME: default`. If the variable is set in the parent
+# environment (e.g. by release.yml -> build.yml) that value wins; else
+# the default below is used (covers local `kas build`).
+env:
+  OE5XRX_RELEASE_TAG: "dev"
 
 target:
   - oe5xrx-remotestation-image


### PR DESCRIPTION
## What / Why

`v1-Gamma` was built + released but the resulting image reports `OE5XRX_RELEASE="dev"` in `/etc/os-release`. Workflow logs confirm `OE5XRX_RELEASE_TAG=v1-Gamma` made it to the workflow env, so the problem is between there and bitbake.

Root cause: **kas scrubs the shell environment** before invoking bitbake. Neither my shell-level `export BB_ENV_PASSTHROUGH_ADDITIONS=...` nor the local_conf_header append survived — bitbake's `OE5XRX_RELEASE_TAG ??= "dev"` fallback kicked in.

## Fix

kas's `env:` block is the documented way to forward env vars. Variables listed there are forwarded to bitbake; the listed value is used as default when the parent env has no value. Moved `OE5XRX_RELEASE_TAG` into `oe5xrx.yml:env:`, removed the now-useless dance in `build.yml` and the passthrough append in `local_conf_header`.

## Testing

- `yaml.safe_load` on both changed files → OK.
- Real test: re-tag + re-release, boot the image, `cat /etc/os-release` should show the actual tag.