### PR TITLE
image: install bzip2 CLI

### DIFF
--- a/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/images/oe5xrx-remotestation-image.bb
@@ -15,6 +15,10 @@ IMAGE_INSTALL = " \
     ab-layout \
 "
 
+# bzip2 CLI is a convenience for manual debugging of downloaded .wic.bz2
+# images on-device. The station-agent uses Python stdlib bz2 internally.
+IMAGE_INSTALL:append = " bzip2"
+
 # ---- Read-only rootfs + overlayfs-etc (all machines) -----------------------
 
 IMAGE_FEATURES += " \


### PR DESCRIPTION
Convenience for debugging downloaded .wic.bz2 images on-device.
The station-agent's OTA flow uses Python stdlib bz2 internally, so
this adds no runtime dependency — it's purely for ssh/serial debug
sessions where an operator wants to inspect or verify a downloaded
image manually.

Ships alongside the server-side OTA upgrade flow in station-manager.