### PR TITLE
scripts: timestamped release helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,17 @@
 name: Release
 
-# Runs on `vX.Y.Z` tag push. Builds BOTH images (x86-64 + Raspberry Pi),
+# Runs on release-tag push. Builds BOTH images (x86-64 + Raspberry Pi),
 # checksums them, signs the bundles with cosign keyless (Sigstore + OIDC),
 # and publishes a GitHub Release with everything attached.
+#
+# Tag format is YYYY.MM.DD-HH (UTC), with optional single-letter suffix
+# for same-hour hotfixes. See scripts/release.sh.
+# 'v*' is still matched so legacy tags (v1-alpha ... v1-delta) keep working.
 on:
   push:
-    tags: ['v*']
+    tags:
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-[0-9][0-9]*'
+      - 'v*'
 
 permissions:
   contents: write       # create release, upload assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ name: Release
 # checksums them, signs the bundles with cosign keyless (Sigstore + OIDC),
 # and publishes a GitHub Release with everything attached.
 #
-# Tag format is YYYY.MM.DD-HH (UTC), with optional single-letter suffix
-# for same-hour hotfixes. See scripts/release.sh.
+# Tag format is YYYY.MM.DD-HH (UTC), with an optional single lowercase
+# letter [a-z] suffix for same-hour hotfixes. See scripts/release.sh.
 #
 # The legacy v* tags (v1-alpha ... v1-delta) stay on GitHub as
 # historical releases — run-qemu.sh can still fetch them — but pushing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,11 @@ name: Release
 #
 # Tag format is YYYY.MM.DD-HH (UTC), with optional single-letter suffix
 # for same-hour hotfixes. See scripts/release.sh.
-# 'v*' is still matched so legacy tags (v1-alpha ... v1-delta) keep working.
+#
+# The legacy v* tags (v1-alpha ... v1-delta) stay on GitHub as
+# historical releases — run-qemu.sh can still fetch them — but pushing
+# a new v* tag will NOT trigger a build. Only the timestamp format is
+# accepted going forward.
 on:
   push:
     tags:
@@ -14,8 +18,6 @@ on:
       - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-[0-9][0-9]'
       # YYYY.MM.DD-HH[a-z] — same-hour hotfix
       - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-[0-9][0-9][a-z]'
-      # Legacy v* tags (v1-alpha ... v1-delta) still build.
-      - 'v*'
 
 permissions:
   contents: write       # create release, upload assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,11 @@ name: Release
 on:
   push:
     tags:
-      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-[0-9][0-9]*'
+      # YYYY.MM.DD-HH (no suffix) — the common case
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-[0-9][0-9]'
+      # YYYY.MM.DD-HH[a-z] — same-hour hotfix
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-[0-9][0-9][a-z]'
+      # Legacy v* tags (v1-alpha ... v1-delta) still build.
       - 'v*'
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -286,18 +286,30 @@ change goes through PR review.
 
 ### Releases
 
-Pushing a `vX.Y.Z` tag triggers `release.yml`:
+Rolling releases are tagged as `YYYY.MM.DD-HH` in UTC (e.g.
+`2026.04.19-14`). Use the helper:
 
 ```bash
-git tag v1.0.0
-git push origin v1.0.0
+./scripts/release.sh
 ```
 
-This builds **both** machine images (qemux86-64 + raspberrypi4-64),
-signs them with cosign keyless (Sigstore + GitHub Actions OIDC), and
-publishes a GitHub Release with the images, SHA256 checksums, and
-signature bundles. See [SECURITY.md](SECURITY.md) for how to verify a
-release before flashing it.
+It verifies the working tree is clean + in sync with `origin/main`,
+generates the timestamp tag, shows the commits that will be included,
+asks for confirmation, then tags and pushes. The push triggers
+`release.yml`, which builds **both** machine images (qemux86-64 +
+raspberrypi4-64), signs them with cosign keyless (Sigstore + GitHub
+Actions OIDC), and publishes a GitHub Release with the images, SHA256
+checksums, and signature bundles. See [SECURITY.md](SECURITY.md) for
+how to verify a release before flashing it.
+
+For a same-hour hotfix (rare), pass an explicit tag with a suffix:
+
+```bash
+./scripts/release.sh --tag 2026.04.19-14b
+```
+
+Legacy `v*` tags (`v1-alpha` … `v1-delta`) still trigger the workflow
+for compatibility, but new releases should use the timestamp form.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -309,11 +309,13 @@ For a same-hour hotfix (rare), pass a lowercase suffix letter:
 ./scripts/release.sh --suffix b    # -> 2026.04.19-14b if a is taken too
 ```
 
-The helper only emits tags matching `YYYY.MM.DD-HH[a-z]?`, which is
-also the exact set the release workflow triggers on. Legacy `v*`
-releases (`v1-alpha` … `v1-delta`) stay on GitHub as historical
-artifacts — `scripts/run-qemu.sh --release v1-delta` can still fetch
-them — but pushing a new `v*` tag no longer triggers a build.
+The helper only emits tags in the form `YYYY.MM.DD-HH` or
+`YYYY.MM.DD-HH<suffix>` where `<suffix>` is a single lowercase letter
+`a`–`z`; this is also the exact set the release workflow triggers on.
+Legacy `v*` releases (`v1-alpha` … `v1-delta`) stay on GitHub as
+historical artifacts — `scripts/run-qemu.sh --release v1-delta` can
+still fetch them — but pushing a new `v*` tag no longer triggers a
+build.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -302,14 +302,18 @@ Actions OIDC), and publishes a GitHub Release with the images, SHA256
 checksums, and signature bundles. See [SECURITY.md](SECURITY.md) for
 how to verify a release before flashing it.
 
-For a same-hour hotfix (rare), pass an explicit tag with a suffix:
+For a same-hour hotfix (rare), pass a lowercase suffix letter:
 
 ```bash
-./scripts/release.sh --tag 2026.04.19-14b
+./scripts/release.sh --suffix a    # -> 2026.04.19-14a
+./scripts/release.sh --suffix b    # -> 2026.04.19-14b if a is taken too
 ```
 
-Legacy `v*` tags (`v1-alpha` … `v1-delta`) still trigger the workflow
-for compatibility, but new releases should use the timestamp form.
+The helper only emits tags matching `YYYY.MM.DD-HH[a-z]?`, which is
+also the exact set the release workflow triggers on. Legacy `v*`
+releases (`v1-alpha` … `v1-delta`) stay on GitHub as historical
+artifacts — `scripts/run-qemu.sh --release v1-delta` can still fetch
+them — but pushing a new `v*` tag no longer triggers a build.
 
 ---
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -139,8 +139,10 @@ fi
 if [[ $ASSUME_YES -eq 0 ]]; then
     echo
     read -r -p "Create and push this release? [y/N] " answer
-    case "${answer,,}" in
-    y | yes) ;;
+    # Match y/Y/yes/YES/Yes without ${var,,} — that's bash 4+, and
+    # macOS still ships bash 3.2 by default.
+    case "$answer" in
+    [yY] | [yY][eE][sS]) ;;
     *) echo "Aborted."; exit 1 ;;
     esac
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Release helper for OE5XRX linux-image.
+#
+# Creates a timestamped git tag in `YYYY.MM.DD-HH` UTC format and pushes
+# it to origin. The push triggers `.github/workflows/release.yml`, which
+# builds both images (qemux86-64 + raspberrypi4-64), signs them with
+# cosign keyless, and publishes a GitHub Release with the artifacts.
+#
+# Usage:
+#   scripts/release.sh                   # auto-tag as UTC YYYY.MM.DD-HH
+#   scripts/release.sh --tag 2026.04.19-14b   # override (hotfix inside the same hour)
+#   scripts/release.sh --dry-run         # preview; don't tag or push
+#   scripts/release.sh --yes             # skip the confirmation prompt
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: scripts/release.sh [--tag <tag>] [--dry-run] [--yes]
+
+Creates a timestamped tag (UTC, hour granularity) and pushes it.
+The release.yml workflow takes over from there.
+
+Options:
+  --tag <tag>   Override auto-generated tag. Use this only when you
+                need a hotfix in the same hour as a prior release
+                (e.g. "2026.04.19-14b").
+  --dry-run     Print what would happen; make no changes.
+  --yes         Skip the interactive confirmation prompt.
+  -h, --help    Show this help.
+EOF
+}
+
+DRY_RUN=0
+ASSUME_YES=0
+CUSTOM_TAG=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -n | --dry-run) DRY_RUN=1; shift ;;
+    -y | --yes) ASSUME_YES=1; shift ;;
+    --tag)
+        [[ $# -ge 2 ]] || { echo "--tag requires a value" >&2; exit 2; }
+        CUSTOM_TAG="$2"
+        shift 2
+        ;;
+    -h | --help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+command -v gh >/dev/null 2>&1 || {
+    echo "This script expects the 'gh' CLI (only to check auth state)." >&2
+    exit 1
+}
+
+branch=$(git symbolic-ref --short HEAD)
+if [[ "$branch" != "main" ]]; then
+    echo "Must be on main to release (currently on: $branch)." >&2
+    exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+    echo "Working tree is not clean. Commit or stash first." >&2
+    exit 1
+fi
+
+git fetch origin main --quiet
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse origin/main)
+if [[ "$local_sha" != "$remote_sha" ]]; then
+    echo "Local main (${local_sha:0:8}) differs from origin/main (${remote_sha:0:8})." >&2
+    echo "Pull first so the tag points at the published HEAD." >&2
+    exit 1
+fi
+
+if [[ -n "$CUSTOM_TAG" ]]; then
+    tag="$CUSTOM_TAG"
+    # Same charset as OE5XRX_RELEASE_TAG in the image recipe — anything
+    # outside that range breaks os-release parsing downstream.
+    if ! [[ "$tag" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        echo "Custom tag '$tag' contains characters outside [A-Za-z0-9._-]." >&2
+        exit 1
+    fi
+else
+    tag=$(date -u +%Y.%m.%d-%H)
+fi
+
+if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+    echo "Tag '$tag' already exists locally." >&2
+    echo "For a hotfix inside the same hour, re-run with --tag ${tag}b." >&2
+    exit 1
+fi
+
+if git ls-remote --tags --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+    echo "Tag '$tag' already exists on origin." >&2
+    echo "For a hotfix inside the same hour, re-run with --tag ${tag}b." >&2
+    exit 1
+fi
+
+last_tag=$(git describe --tags --abbrev=0 2>/dev/null || true)
+
+echo "============================================"
+echo "  Tag:     $tag"
+echo "  Commit:  $(git rev-parse --short HEAD)  $(git log -1 --format=%s)"
+echo "  Since:   ${last_tag:-<no previous tag>}"
+echo "============================================"
+
+if [[ -n "$last_tag" ]]; then
+    echo
+    echo "Commits in this release:"
+    git log --pretty=format:"  %h %s" "${last_tag}..HEAD"
+    echo
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo
+    echo "(dry run — no tag created, no push)"
+    exit 0
+fi
+
+if [[ $ASSUME_YES -eq 0 ]]; then
+    echo
+    read -r -p "Create and push this release? [y/N] " answer
+    case "${answer,,}" in
+    y | yes) ;;
+    *) echo "Aborted."; exit 1 ;;
+    esac
+fi
+
+git tag -a "$tag" -m "Release $tag"
+git push origin "$tag"
+
+echo
+echo "Tag pushed. release.yml is now building both images + publishing the release."
+echo "Watch: gh run watch --repo OE5XRX/linux-image \$(gh run list --repo OE5XRX/linux-image --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,7 +66,7 @@ if [[ -n "$SUFFIX" ]] && ! [[ "$SUFFIX" =~ ^[a-z]$ ]]; then
     exit 2
 fi
 
-branch=$(git symbolic-ref --short HEAD)
+branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "<detached>")
 if [[ "$branch" != "main" ]]; then
     echo "Must be on main to release (currently on: $branch)." >&2
     exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,42 +7,53 @@
 # builds both images (qemux86-64 + raspberrypi4-64), signs them with
 # cosign keyless, and publishes a GitHub Release with the artifacts.
 #
+# Valid tag formats:
+#   YYYY.MM.DD-HH        — normal release (default)
+#   YYYY.MM.DD-HH[a-z]   — same-hour hotfix, bump the letter each time
+#
+# The script enforces this shape so a typo can't push a tag that the
+# release.yml workflow silently refuses to build.
+#
 # Usage:
-#   scripts/release.sh                   # auto-tag as UTC YYYY.MM.DD-HH
-#   scripts/release.sh --tag 2026.04.19-14b   # override (hotfix inside the same hour)
-#   scripts/release.sh --dry-run         # preview; don't tag or push
-#   scripts/release.sh --yes             # skip the confirmation prompt
+#   scripts/release.sh                  # auto-tag YYYY.MM.DD-HH (UTC)
+#   scripts/release.sh --suffix a       # hotfix inside the same UTC hour
+#   scripts/release.sh --dry-run        # preview; don't tag or push
+#   scripts/release.sh --yes            # skip the confirmation prompt
 
 set -euo pipefail
 
+readonly TAG_RE='^[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9]{2}[a-z]?$'
+
 usage() {
     cat <<EOF
-Usage: scripts/release.sh [--tag <tag>] [--dry-run] [--yes]
+Usage: scripts/release.sh [--suffix <a-z>] [--dry-run] [--yes]
 
 Creates a timestamped tag (UTC, hour granularity) and pushes it.
 The release.yml workflow takes over from there.
 
 Options:
-  --tag <tag>   Override auto-generated tag. Use this only when you
-                need a hotfix in the same hour as a prior release
-                (e.g. "2026.04.19-14b").
-  --dry-run     Print what would happen; make no changes.
-  --yes         Skip the interactive confirmation prompt.
-  -h, --help    Show this help.
+  --suffix <letter>  Append a single lowercase letter [a-z] to the base
+                     tag. Use this only when a prior release already
+                     fired in the same UTC hour (e.g. 2026.04.19-14
+                     exists -> --suffix a -> 2026.04.19-14a). Bump the
+                     letter if 14a is also taken.
+  --dry-run          Print what would happen; make no changes.
+  --yes              Skip the interactive confirmation prompt.
+  -h, --help         Show this help.
 EOF
 }
 
 DRY_RUN=0
 ASSUME_YES=0
-CUSTOM_TAG=""
+SUFFIX=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
     -n | --dry-run) DRY_RUN=1; shift ;;
     -y | --yes) ASSUME_YES=1; shift ;;
-    --tag)
-        [[ $# -ge 2 ]] || { echo "--tag requires a value" >&2; exit 2; }
-        CUSTOM_TAG="$2"
+    --suffix)
+        [[ $# -ge 2 ]] || { echo "--suffix requires a value [a-z]" >&2; exit 2; }
+        SUFFIX="$2"
         shift 2
         ;;
     -h | --help) usage; exit 0 ;;
@@ -50,10 +61,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-command -v gh >/dev/null 2>&1 || {
-    echo "This script expects the 'gh' CLI (only to check auth state)." >&2
-    exit 1
-}
+if [[ -n "$SUFFIX" ]] && ! [[ "$SUFFIX" =~ ^[a-z]$ ]]; then
+    echo "--suffix must be a single lowercase letter [a-z] (got '$SUFFIX')." >&2
+    exit 2
+fi
 
 branch=$(git symbolic-ref --short HEAD)
 if [[ "$branch" != "main" ]]; then
@@ -61,8 +72,13 @@ if [[ "$branch" != "main" ]]; then
     exit 1
 fi
 
-if ! git diff-index --quiet HEAD --; then
-    echo "Working tree is not clean. Commit or stash first." >&2
+# --porcelain surfaces unstaged, staged, and untracked changes — all
+# three block a release because the tagged commit should fully match
+# what's on origin/main.
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Working tree is not clean. Commit, stash, or ignore first:" >&2
+    echo >&2
+    git status --short >&2
     exit 1
 fi
 
@@ -75,27 +91,27 @@ if [[ "$local_sha" != "$remote_sha" ]]; then
     exit 1
 fi
 
-if [[ -n "$CUSTOM_TAG" ]]; then
-    tag="$CUSTOM_TAG"
-    # Same charset as OE5XRX_RELEASE_TAG in the image recipe — anything
-    # outside that range breaks os-release parsing downstream.
-    if ! [[ "$tag" =~ ^[A-Za-z0-9._-]+$ ]]; then
-        echo "Custom tag '$tag' contains characters outside [A-Za-z0-9._-]." >&2
-        exit 1
+base=$(date -u +%Y.%m.%d-%H)
+tag="${base}${SUFFIX}"
+
+# Paranoia guard — this should never fire since --suffix is validated
+# and `date` emits fixed-width fields, but it keeps the invariant honest.
+if ! [[ "$tag" =~ $TAG_RE ]]; then
+    echo "Internal error: generated tag '$tag' doesn't match $TAG_RE" >&2
+    exit 3
+fi
+
+if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null \
+    || git ls-remote --tags --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
+    echo "Tag '$tag' already exists." >&2
+    if [[ -z "$SUFFIX" ]]; then
+        echo "Re-run with --suffix a for a hotfix in the same UTC hour." >&2
+    elif [[ "$SUFFIX" == "z" ]]; then
+        echo "Out of suffix letters (you've reached z). Wait for the next UTC hour." >&2
+    else
+        next=$(printf "%s" "$SUFFIX" | tr 'a-y' 'b-z')
+        echo "Re-run with --suffix ${next}." >&2
     fi
-else
-    tag=$(date -u +%Y.%m.%d-%H)
-fi
-
-if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
-    echo "Tag '$tag' already exists locally." >&2
-    echo "For a hotfix inside the same hour, re-run with --tag ${tag}b." >&2
-    exit 1
-fi
-
-if git ls-remote --tags --exit-code origin "refs/tags/$tag" >/dev/null 2>&1; then
-    echo "Tag '$tag' already exists on origin." >&2
-    echo "For a hotfix inside the same hour, re-run with --tag ${tag}b." >&2
     exit 1
 fi
 
@@ -134,4 +150,4 @@ git push origin "$tag"
 
 echo
 echo "Tag pushed. release.yml is now building both images + publishing the release."
-echo "Watch: gh run watch --repo OE5XRX/linux-image \$(gh run list --repo OE5XRX/linux-image --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+echo "Watch: https://github.com/OE5XRX/linux-image/actions"

--- a/scripts/run-qemu.sh
+++ b/scripts/run-qemu.sh
@@ -83,6 +83,16 @@ fetch_release() {
     fi
     [ -n "${tag}" ] || { echo "ERROR: no release found" >&2; exit 1; }
 
+    # Accept either the new timestamp tags (YYYY.MM.DD-HH[a-z]) or
+    # legacy v* tags. Anything else is a typo that would otherwise
+    # waste a `gh release download` round-trip before failing opaquely.
+    if ! [[ "${tag}" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9]{2}[a-z]?$ ]] \
+        && ! [[ "${tag}" =~ ^v[A-Za-z0-9._-]+$ ]]; then
+        echo "ERROR: '${tag}' is not a valid release tag." >&2
+        echo "Expected YYYY.MM.DD-HH[a-z] or legacy v*." >&2
+        exit 1
+    fi
+
     RELEASE_DIR="${CACHE_DIR}/release-${tag}"
     mkdir -p "${RELEASE_DIR}"
 

--- a/scripts/run-qemu.sh
+++ b/scripts/run-qemu.sh
@@ -89,7 +89,7 @@ fetch_release() {
     if ! [[ "${tag}" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9]{2}[a-z]?$ ]] \
         && ! [[ "${tag}" =~ ^v[A-Za-z0-9._-]+$ ]]; then
         echo "ERROR: '${tag}' is not a valid release tag." >&2
-        echo "Expected YYYY.MM.DD-HH[a-z] or legacy v*." >&2
+        echo "Expected YYYY.MM.DD-HH or YYYY.MM.DD-HH[a-z], or legacy v*." >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

Adds `scripts/release.sh` to cut rolling releases as `YYYY.MM.DD-HH` UTC tags. The greek-letter scheme (`v1-alpha` … `v1-delta`) was due to either run out of letters or force a semver-style "what belongs in v2" decision that doesn't match a rolling model.

## What the script does

1. Refuses to run unless you're on a clean, up-to-date `main`.
2. Generates `$(date -u +%Y.%m.%d-%H)` for the tag. Same-hour hotfixes use `--suffix <a-z>` (e.g. `2026.04.19-14a`).
3. Prints the commits since the last tag, asks for confirmation.
4. Creates an annotated tag, pushes it, then `release.yml` takes over (build both machines + cosign + GitHub Release — unchanged).

`--dry-run` previews; `--yes` skips the prompt for scripted use.

## Strict tag format everywhere

The regex `^[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9]{2}[a-z]?$` is the only accepted shape, enforced in three places so they can't drift:

- `scripts/release.sh` — can only emit tags in that form (no freeform override)
- `.github/workflows/release.yml` — two explicit glob patterns (base + hotfix), nothing else
- `scripts/run-qemu.sh` — same regex + legacy `v*` for historical fetches only

## Legacy v* tags

Pushing a new `v*` tag no longer triggers a build. The existing `v1-alpha` … `v1-delta` releases stay on GitHub as historical artifacts and can still be fetched via `scripts/run-qemu.sh --release v1-delta` for testing against old images.

Since this PR edits `.github/workflows/release.yml`, the gh PAT can't push through auto-merge — needs the browser merge.

## Tradeoff noted

Hour granularity means two releases in the same UTC hour collide. The script prints which `--suffix` letter to try next, and refuses to continue past `z` (wait for the next hour). Minute granularity would avoid it at the cost of two more characters in every tag; given the realistic release cadence, hour wins.

## Test plan

- [x] `bash -n scripts/release.sh` — syntax clean
- [x] `scripts/release.sh --dry-run` from a feature branch — refuses (must be on main)
- [x] `scripts/release.sh --suffix abc` / `--suffix 1` — refuses (must be single lowercase letter)
- [ ] Merge this, then `./scripts/release.sh --dry-run` from main — preview only
- [ ] `./scripts/release.sh` — cuts the first timestamped release; confirm `release.yml` runs and publishes to the GitHub Releases page

🤖 Generated with [Claude Code](https://claude.com/claude-code)