### PR TITLE
Treat station-agent SRCREV as a lockfile, add preflight gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
             echo "::error file=$recipe::Recipe not found"
             exit 1
           fi
-          line=$(grep -E '^SRCREV[[:space:]]*=' "$recipe" || true)
+          # Tolerate leading whitespace — BitBake accepts it even if
+          # style-wise nobody writes recipes that way.
+          line=$(grep -E '^[[:space:]]*SRCREV[[:space:]]*=' "$recipe" || true)
           if [ -z "$line" ]; then
             echo "::error file=$recipe::No SRCREV line found"
             exit 1
@@ -58,13 +60,19 @@ jobs:
             echo "::error file=$recipe::SRCREV is \${AUTOREV} on a release tag — run scripts/pin-station-agent.sh before tagging"
             exit 1
           fi
-          sha=$(printf '%s' "$line" | sed -E 's/^SRCREV[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          # Strip the `SRCREV =` prefix, then peel off surrounding
+          # quotes — accept both " and ' since BitBake allows either.
+          # Using sed -n+p so a non-match yields empty output and the
+          # 40-char regex check below surfaces a clear error rather
+          # than the whole unparsed line.
+          raw=$(printf '%s\n' "$line" | sed -nE 's/^[[:space:]]*SRCREV[[:space:]]*=[[:space:]]*(.*)$/\1/p')
+          sha=$(printf '%s' "$raw" | sed -E 's/^"([^"]*)".*$/\1/; s/^'"'"'([^'"'"']*)'"'"'.*$/\1/')
           # Git accepts mixed-case hex for commit IDs (the Yocto fetcher
           # doesn't care either). Reject anything that isn't exactly 40
           # hex chars, but allow upper/lowercase — otherwise a human-pasted
           # SHA from GitHub's UI could fail preflight despite being valid.
           if ! printf '%s' "$sha" | grep -Eq '^[0-9a-fA-F]{40}$'; then
-            echo "::error file=$recipe::SRCREV '$sha' is not a full 40-char SHA"
+            echo "::error file=$recipe::SRCREV value '$sha' is not a full 40-char SHA"
             exit 1
           fi
           echo "OK — station-agent pinned to $sha"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,45 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Cheap preflight gate: makes the build fail within seconds (no Yocto
+  # spin-up) if the station-agent recipe still uses ${AUTOREV}. On a
+  # release tag we require a pinned SHA so the image is reproducible —
+  # otherwise a later rebuild of the same tag could silently pick up a
+  # different agent revision. See scripts/pin-station-agent.sh.
+  preflight:
+    name: Preflight — require pinned SRCREV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Fail if station-agent SRCREV is AUTOREV
+        run: |
+          set -euo pipefail
+          recipe=meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
+          if [ ! -f "$recipe" ]; then
+            echo "::error file=$recipe::Recipe not found"
+            exit 1
+          fi
+          line=$(grep -E '^SRCREV[[:space:]]*=' "$recipe" || true)
+          if [ -z "$line" ]; then
+            echo "::error file=$recipe::No SRCREV line found"
+            exit 1
+          fi
+          echo "Found: $line"
+          if printf '%s' "$line" | grep -qF '${AUTOREV}'; then
+            echo "::error file=$recipe::SRCREV is \${AUTOREV} on a release tag — run scripts/pin-station-agent.sh before tagging"
+            exit 1
+          fi
+          sha=$(printf '%s' "$line" | sed -E 's/^SRCREV[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error file=$recipe::SRCREV '$sha' is not a full 40-char SHA"
+            exit 1
+          fi
+          echo "OK — station-agent pinned to $sha"
+
   build-x64:
     name: Build qemux86-64
+    needs: preflight
     uses: ./.github/workflows/build.yml
     with:
       machine: qemux86-64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,11 @@ jobs:
             exit 1
           fi
           sha=$(printf '%s' "$line" | sed -E 's/^SRCREV[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
-          if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+          # Git accepts mixed-case hex for commit IDs (the Yocto fetcher
+          # doesn't care either). Reject anything that isn't exactly 40
+          # hex chars, but allow upper/lowercase — otherwise a human-pasted
+          # SHA from GitHub's UI could fail preflight despite being valid.
+          if ! printf '%s' "$sha" | grep -Eq '^[0-9a-fA-F]{40}$'; then
             echo "::error file=$recipe::SRCREV '$sha' is not a full 40-char SHA"
             exit 1
           fi

--- a/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
@@ -8,8 +8,10 @@ SRC_URI = " \
     file://station-agent.service \
     file://config.yml \
 "
-# FIXME(srcrev-pin): Pin to a specific commit before first production rollout.
-SRCREV = "${AUTOREV}"
+# Lockfile-style pin: SRCREV is always a specific commit, never ${AUTOREV}.
+# Bump via scripts/pin-station-agent.sh, commit like any dependency update.
+# The release workflow's preflight job refuses to build with AUTOREV.
+SRCREV = "138fbac2c005f20cb819cad0cb18067627f7fc2c"
 PV = "0.1.0+git${SRCPV}"
 
 S = "${WORKDIR}/station_agent"

--- a/scripts/pin-station-agent.sh
+++ b/scripts/pin-station-agent.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Update the station-agent lock in the Yocto recipe.
+#
+# The recipe's SRCREV is treated as a lockfile — similar to a git
+# submodule's recorded commit, or the "resolved" field in package-lock.json.
+# It always points at a specific station-manager commit, never at a
+# moving branch via ${AUTOREV}. Bumping to a newer agent is a normal
+# commit like any other dependency bump.
+#
+# This script resolves a SHA (either main@HEAD by default, or one you
+# pass explicitly) and rewrites the SRCREV line. Commit the result.
+#
+# Usage:
+#   scripts/pin-station-agent.sh                   # lock to latest main HEAD
+#   scripts/pin-station-agent.sh <sha>             # lock to a specific SHA
+#   scripts/pin-station-agent.sh --dry-run         # preview; no file writes
+
+set -euo pipefail
+
+readonly RECIPE="meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb"
+readonly UPSTREAM="https://github.com/OE5XRX/station-manager.git"
+readonly BRANCH="main"
+
+usage() {
+    cat <<EOF
+Usage: scripts/pin-station-agent.sh [<sha>] [--dry-run]
+
+Rewrites SRCREV in the station-agent Yocto recipe to a specific commit.
+The recipe is treated as a lockfile — a real SHA is always committed.
+
+Arguments:
+  <sha>        Full 40-char SHA. Defaults to HEAD of
+               OE5XRX/station-manager@${BRANCH}.
+
+Options:
+  --dry-run    Print the resulting recipe change; don't modify files.
+  -h, --help   Show this help.
+EOF
+}
+
+DRY_RUN=0
+EXPLICIT_SHA=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -n | --dry-run) DRY_RUN=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    -*) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *)
+        if [[ -n "$EXPLICIT_SHA" ]]; then
+            echo "Only one SHA argument allowed." >&2
+            exit 2
+        fi
+        EXPLICIT_SHA="$1"
+        shift
+        ;;
+    esac
+done
+
+if [[ ! -f "$RECIPE" ]]; then
+    echo "Recipe not found: $RECIPE" >&2
+    echo "Run from the repo root." >&2
+    exit 1
+fi
+
+if [[ -n "$EXPLICIT_SHA" ]]; then
+    if ! [[ "$EXPLICIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "SHA must be a full 40-char lowercase hex string." >&2
+        echo "Got: $EXPLICIT_SHA" >&2
+        exit 2
+    fi
+    sha="$EXPLICIT_SHA"
+else
+    echo "Resolving ${BRANCH} HEAD of ${UPSTREAM} ..." >&2
+    sha=$(git ls-remote "$UPSTREAM" "refs/heads/${BRANCH}" | awk '{print $1}')
+    if [[ -z "$sha" ]]; then
+        echo "Failed to resolve ${BRANCH} HEAD of ${UPSTREAM}." >&2
+        exit 1
+    fi
+fi
+new_line="SRCREV = \"${sha}\""
+
+current_line=$(grep -E '^SRCREV\s*=' "$RECIPE" || true)
+if [[ -z "$current_line" ]]; then
+    echo "No SRCREV line found in $RECIPE — unexpected recipe layout." >&2
+    exit 1
+fi
+
+echo "Before: ${current_line}"
+echo "After:  ${new_line}"
+
+if [[ "$current_line" == "$new_line" ]]; then
+    echo "(no change — already locked to this SHA)"
+    exit 0
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo
+    echo "(dry run — no changes written)"
+    exit 0
+fi
+
+# In-place edit without GNU vs BSD sed headaches. Only the first match is
+# rewritten, which is the top-of-file SRCREV assignment.
+tmp=$(mktemp)
+awk -v new="$new_line" '
+    !done && /^SRCREV[[:space:]]*=/ { print new; done=1; next }
+    { print }
+' "$RECIPE" > "$tmp"
+mv "$tmp" "$RECIPE"
+
+echo
+echo "Recipe updated. Diff:"
+git --no-pager diff -- "$RECIPE" | sed 's/^/  /'
+echo
+echo "Next: commit the lock bump."
+echo "  git add $RECIPE"
+echo "  git commit -m \"Bump station-agent to ${sha:0:8}\""

--- a/scripts/pin-station-agent.sh
+++ b/scripts/pin-station-agent.sh
@@ -24,18 +24,18 @@ readonly BRANCH="main"
 
 usage() {
     cat <<EOF
-Usage: scripts/pin-station-agent.sh [<sha>] [--dry-run]
+Usage: scripts/pin-station-agent.sh [<sha>] [-n | --dry-run]
 
 Rewrites SRCREV in the station-agent Yocto recipe to a specific commit.
 The recipe is treated as a lockfile — a real SHA is always committed.
 
 Arguments:
-  <sha>        Full 40-char SHA. Defaults to HEAD of
-               OE5XRX/station-manager@${BRANCH}.
+  <sha>              Full 40-char SHA. Defaults to HEAD of
+                     OE5XRX/station-manager@${BRANCH}.
 
 Options:
-  --dry-run    Print the resulting recipe change; don't modify files.
-  -h, --help   Show this help.
+  -n, --dry-run      Print the resulting recipe change; don't modify files.
+  -h, --help         Show this help.
 EOF
 }
 
@@ -106,7 +106,10 @@ fi
 
 # In-place edit without GNU vs BSD sed headaches. Only the first match is
 # rewritten, which is the top-of-file SRCREV assignment.
-tmp=$(mktemp)
+# Pass an explicit template — `mktemp` without one works on GNU coreutils
+# but fails on BSD/macOS, and we claim bash 3.2 compatibility elsewhere
+# in this script.
+tmp=$(mktemp "${TMPDIR:-/tmp}/pin-station-agent.XXXXXX")
 trap 'rm -f "$tmp"' EXIT
 awk -v new="$new_line" '
     !done && /^SRCREV[[:space:]]*=/ { print new; done=1; next }

--- a/scripts/pin-station-agent.sh
+++ b/scripts/pin-station-agent.sh
@@ -121,9 +121,17 @@ awk -v new="$new_line" '
 cat "$tmp" > "$RECIPE"
 
 echo
-echo "Recipe updated. Diff:"
-git --no-pager diff -- "$RECIPE" | sed 's/^/  /'
-echo
-echo "Next: commit the lock bump."
-echo "  git add $RECIPE"
-echo "  git commit -m \"Bump station-agent to ${sha:0:8}\""
+# `git diff` fails under `set -e` if we're not in a git worktree (e.g.
+# the script was unpacked from a tarball). The recipe is already
+# rewritten at this point — don't punish the caller with a non-zero
+# exit just because the nicety at the end can't run.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Recipe updated. Diff:"
+    git --no-pager diff -- "$RECIPE" | sed 's/^/  /'
+    echo
+    echo "Next: commit the lock bump."
+    echo "  git add $RECIPE"
+    echo "  git commit -m \"Bump station-agent to ${sha:0:8}\""
+else
+    echo "Recipe updated (git diff unavailable: not inside a git worktree)."
+fi

--- a/scripts/pin-station-agent.sh
+++ b/scripts/pin-station-agent.sh
@@ -65,12 +65,15 @@ if [[ ! -f "$RECIPE" ]]; then
 fi
 
 if [[ -n "$EXPLICIT_SHA" ]]; then
-    if ! [[ "$EXPLICIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-        echo "SHA must be a full 40-char lowercase hex string." >&2
+    if ! [[ "$EXPLICIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+        echo "SHA must be a full 40-char hex string." >&2
         echo "Got: $EXPLICIT_SHA" >&2
         exit 2
     fi
-    sha="$EXPLICIT_SHA"
+    # Normalize to lowercase so the recipe stays consistent regardless
+    # of where the user copy-pasted the SHA from. `tr` keeps this
+    # compatible with bash 3.2 (macOS), ${var,,} wouldn't.
+    sha=$(printf '%s' "$EXPLICIT_SHA" | tr 'A-F' 'a-f')
 else
     echo "Resolving ${BRANCH} HEAD of ${UPSTREAM} ..." >&2
     sha=$(git ls-remote "$UPSTREAM" "refs/heads/${BRANCH}" | awk '{print $1}')
@@ -81,7 +84,7 @@ else
 fi
 new_line="SRCREV = \"${sha}\""
 
-current_line=$(grep -E '^SRCREV\s*=' "$RECIPE" || true)
+current_line=$(grep -E '^SRCREV[[:space:]]*=' "$RECIPE" || true)
 if [[ -z "$current_line" ]]; then
     echo "No SRCREV line found in $RECIPE — unexpected recipe layout." >&2
     exit 1
@@ -104,11 +107,15 @@ fi
 # In-place edit without GNU vs BSD sed headaches. Only the first match is
 # rewritten, which is the top-of-file SRCREV assignment.
 tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
 awk -v new="$new_line" '
     !done && /^SRCREV[[:space:]]*=/ { print new; done=1; next }
     { print }
 ' "$RECIPE" > "$tmp"
-mv "$tmp" "$RECIPE"
+# Write back via redirection to the existing recipe path so the file's
+# tracked mode (0644) is preserved. `mv "$tmp" "$RECIPE"` would replace
+# $RECIPE with the tmp file's 0600 mode and flip git's recorded mode.
+cat "$tmp" > "$RECIPE"
 
 echo
 echo "Recipe updated. Diff:"


### PR DESCRIPTION
## Summary

- Pin \`SRCREV\` to the station-manager PR #21 merge commit (\`138fbac2\`) in \`station-agent_0.1.0.bb\`; drop \`\${AUTOREV}\`.
- Add \`scripts/pin-station-agent.sh\` to bump the lock — resolves \`main@HEAD\` or an explicit SHA, rewrites the recipe. Supports \`--dry-run\`.
- Add a \`preflight\` job to \`release.yml\` that fails in seconds if SRCREV is \`\${AUTOREV}\` or not a full 40-char SHA.

## Why

Our first production test was flashed from linux-image \`2026.04.19-13\`, built ~8 h before PR #21 merged into station-manager \`main\`. With \`AUTOREV\`, the agent inside that image is whatever \`main@HEAD\` was at build time — in our case, pre-OTA code. Station pulls heartbeat but the deployment sits at \`PENDING\` forever because the agent doesn't know about \`/api/v1/deployments/check/\`.

The lockfile pattern (à la \`package-lock.json\` or git submodule record) makes "which agent is in this image" visible in every diff and reproducible across rebuilds.

## Test plan

- [ ] \`scripts/pin-station-agent.sh --dry-run\` prints \`Before/After\` and exits without writes.
- [ ] \`scripts/pin-station-agent.sh\` updates the recipe to current \`main@HEAD\`.
- [ ] \`scripts/pin-station-agent.sh <bogus-sha>\` rejects input that isn't a 40-char hex.
- [ ] After merging, cut a release via \`scripts/release.sh\` — the \`preflight\` job passes, builds trigger as usual.
- [ ] (negative) Revert SRCREV to \`\${AUTOREV}\` on a throwaway branch, push a tag → preflight fails with the actionable error message.

Closes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)