### PR TITLE
Bump station-agent to 4530d47 (multi-stream bz2 fix)

### DIFF
--- a/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
@@ -11,7 +11,7 @@ SRC_URI = " \
 # Lockfile-style pin: SRCREV is always a specific commit, never ${AUTOREV}.
 # Bump via scripts/pin-station-agent.sh, commit like any dependency update.
 # The release workflow's preflight job refuses to build with AUTOREV.
-SRCREV = "138fbac2c005f20cb819cad0cb18067627f7fc2c"
+SRCREV = "4530d47a7486f8e5c19c07f7feda2a2f631010a1"
 PV = "0.1.0+git${SRCPV}"
 
 S = "${WORKDIR}/station_agent"


### PR DESCRIPTION
## Summary

Bumps station-agent SRCREV from \`138fbac2\` to \`4530d47a\` — picks up [station-manager#27](https://github.com/OE5XRX/station-manager/pull/27), which fixes \`install_to_slot()\` to handle multi-stream bz2 files.

## Why

Live install failure on 2026-04-21 03:18:49:

\`\`\`
station_agent.ota: Writing .../firmware-2026.04.20-20.wic.bz2 to /dev/disk/by-partlabel/root_b (slot b)
station_agent: OTA check failed unexpectedly: End of stream already reached
\`\`\`

\`bzip2 -tv\` on the artifact was \`ok\`, so the payload was fine — the agent's manual \`BZ2Decompressor\` loop just couldn't handle concatenated streams (which is exactly what Yocto's parallel compression emits). PR #27 switched to \`bz2.open()\` and gained regression tests for multi-stream + real-I/O passthrough.

## Test plan

- [x] Preflight passes (\`SRCREV\` is a 40-char SHA, not \`\${AUTOREV}\`).
- [ ] After merge + \`scripts/release.sh\`: \`bzcat release-artifact.wic.bz2 | dd of=/dev/null\` on the built image completes without error.
- [ ] After reflashing the affected VM: the still-PENDING deployment gets picked up, downloads, installs, reboots, verifies, commits — full OTA cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)