### PR TITLE
Bump station-agent to db2a8b9 (reboot + slot detection + trial-flag guard)

### DIFF
--- a/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
@@ -11,7 +11,7 @@ SRC_URI = " \
 # Lockfile-style pin: SRCREV is always a specific commit, never ${AUTOREV}.
 # Bump via scripts/pin-station-agent.sh, commit like any dependency update.
 # The release workflow's preflight job refuses to build with AUTOREV.
-SRCREV = "4530d47a7486f8e5c19c07f7feda2a2f631010a1"
+SRCREV = "db2a8b9d140ba20c1a9a79a682cefdac2fe79697"
 PV = "0.1.0+git${SRCPV}"
 
 S = "${WORKDIR}/station_agent"


### PR DESCRIPTION
## Summary

Pin station-agent SRCREV to `db2a8b9d140ba20c1a9a79a682cefdac2fe79697` — the squash-merge commit of station-manager#29.

Brings in four agent-side OTA fixes from the 2026-04-22 e2e test on the qemux86-64 station:

- `bootloader.get_active_slot` derived from `/proc/cmdline` + root-mount, not the bootloader env. Prevents `install_to_slot` overwriting the live rootfs on back-to-back OTAs (the failure mode from the Proxmox test).
- `_handle_ota` now issues a real `systemctl reboot` after install (replaces the dev-mode simulation that silently skipped the reboot).
- `_verify_and_commit` reads `upgrade_available` + `bootcount` post-reboot and distinguishes three cases: trial active, prior local commit retrying server commit, rolled back.
- 10s timeout + `OSError` handling on all bootloader env subprocess calls so a wedged `grub-editenv` / `fw_printenv` can't strand the agent in VERIFYING forever.
- Download filename renamed to `.rootfs.bz2` (matches PR #28 server-side extraction) with a one-time sweep of legacy `.wic.bz2` partials.

## Test plan

- [ ] CI builds both qemux86-64 and raspberrypi-cm4 images with the new agent.
- [ ] After merge: cut a new image release tag, reflash the Proxmox test station, trigger an OTA, watch the agent actually reboot into slot_b and verify from /etc/os-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)