### PR TITLE
Bump station-agent to feb4b2e (atomic grub env writes)

### DIFF
--- a/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
+++ b/meta-oe5xrx-remotestation/recipes-core/station-agent/station-agent_0.1.0.bb
@@ -11,7 +11,7 @@ SRC_URI = " \
 # Lockfile-style pin: SRCREV is always a specific commit, never ${AUTOREV}.
 # Bump via scripts/pin-station-agent.sh, commit like any dependency update.
 # The release workflow's preflight job refuses to build with AUTOREV.
-SRCREV = "db2a8b9d140ba20c1a9a79a682cefdac2fe79697"
+SRCREV = "feb4b2e9cc1dc34b8ca42064f541606bb52ebe9e"
 PV = "0.1.0+git${SRCPV}"
 
 S = "${WORKDIR}/station_agent"


### PR DESCRIPTION
## Summary
- SRCREV bump `db2a8b9d` → `feb4b2e9` via `scripts/pin-station-agent.sh`.
- Lands station-manager #31: `set_upgrade_pending` and `commit_boot_local` collapse their chained grub-editenv calls into single atomic invocations (no more half-staged trial state on a mid-write crash/power loss).

## Test plan
- [ ] CI green (recipe validate; preflight refuses AUTOREV).
- [ ] After merge: cut a timestamped release via `scripts/release.sh`, flash test station, OTA-redeploy to exercise the new atomic writes on a real image.