### PR TITLE
CI: per-target cache volumes, parallel x64+rpi builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,7 +280,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           GH_REPO: ${{ github.repository }}
-          RUNNER_LABEL: oe5xrx-yocto-builder-${{ inputs.machine }}
+          RUNNER_LABEL: ${{ env.BUILDER_LABEL }}
         run: |
           # Find and remove the runner if it's still registered
           RUNNER_ID=$(curl -s \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,15 +29,17 @@ on:
         default: ""
 
 concurrency:
-  # Serialize across all callers — the Hetzner cache volume can only be
-  # attached to one build server at a time.
-  group: yocto-build
+  # Serialize per target — each target has its own Hetzner cache volume
+  # (a volume can only attach to one server at a time), but the two
+  # targets can build in parallel.
+  group: yocto-build-${{ inputs.machine }}
   cancel-in-progress: false
 
 env:
   KAS_MACHINE: ${{ inputs.machine }}
   OE5XRX_RELEASE_TAG: ${{ inputs.release_tag || 'dev' }}
-  CACHE_VOLUME_NAME: oe5xrx-yocto-cache
+  CACHE_VOLUME_NAME: oe5xrx-yocto-cache-${{ inputs.machine }}
+  BUILDER_LABEL: oe5xrx-yocto-builder-${{ inputs.machine }}
 
 jobs:
   create-runner:
@@ -95,7 +97,7 @@ jobs:
           HCLOUD_SSH_KEY_NAME: ${{ secrets.HCLOUD_SSH_KEY_NAME }}
         run: |
           SERVER_ID=$(hcloud server create \
-            --name "oe5xrx-yocto-builder" \
+            --name "${BUILDER_LABEL}" \
             --type cx43 \
             --image ubuntu-24.04 \
             --ssh-key "${HCLOUD_SSH_KEY_NAME}" \
@@ -171,7 +173,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           ssh "root@${SERVER_IP}" bash -s -- \
-            "oe5xrx-yocto-builder" "${RUNNER_REG_TOKEN}" "${GH_REPO}" << 'SETUP_SCRIPT'
+            "${BUILDER_LABEL}" "${RUNNER_REG_TOKEN}" "${GH_REPO}" << 'SETUP_SCRIPT'
             set -euo pipefail
             LABEL=$1; TOKEN=$2; REPO=$3
 
@@ -213,7 +215,7 @@ jobs:
   build:
     name: Build Yocto Image
     needs: create-runner
-    runs-on: oe5xrx-yocto-builder
+    runs-on: oe5xrx-yocto-builder-${{ inputs.machine }}
     env:
       LANG: en_US.UTF-8
     steps:
@@ -278,7 +280,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           GH_REPO: ${{ github.repository }}
-          RUNNER_LABEL: oe5xrx-yocto-builder
+          RUNNER_LABEL: oe5xrx-yocto-builder-${{ inputs.machine }}
         run: |
           # Find and remove the runner if it's still registered
           RUNNER_ID=$(curl -s \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,22 @@ jobs:
     outputs:
       server-id: ${{ steps.create.outputs.server-id }}
     steps:
+      - name: Validate machine input
+        # workflow_dispatch has a choice enum; workflow_call only has
+        # `type: string`. Fail fast here so a typo or new caller can't
+        # reach `hcloud server create` before exploding on the missing
+        # volume.
+        env:
+          MACHINE: ${{ inputs.machine }}
+        run: |
+          case "$MACHINE" in
+            qemux86-64|raspberrypi4-64) ;;
+            *)
+              echo "::error::Unsupported machine '$MACHINE'. Must be qemux86-64 or raspberrypi4-64." >&2
+              exit 1
+              ;;
+          esac
+
       - name: Generate Runner Registration Token via API
         id: runner-token
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,9 @@ jobs:
 
   build-rpi:
     name: Build raspberrypi4-64
-    # Serialize after x64: both targets share the same Hetzner cache volume.
-    needs: build-x64
+    # Each target has its own cache volume, so the two builds run in
+    # parallel. Both still gate on preflight.
+    needs: preflight
     uses: ./.github/workflows/build.yml
     with:
       machine: raspberrypi4-64

--- a/README.md
+++ b/README.md
@@ -220,7 +220,10 @@ Three workflows:
 | `GH_PAT` | `build.yml` | Personal access token with `repo` scope — used to fetch a short-lived runner registration token |
 
 The build server is disposable; only sstate-cache and download caches
-are persisted via a named Hetzner volume (`oe5xrx-yocto-cache`).
+are persisted via per-target named Hetzner volumes
+(`oe5xrx-yocto-cache-qemux86-64`, `oe5xrx-yocto-cache-raspberrypi4-64`).
+Each target has its own volume so both builds can run in parallel on a
+release.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -203,10 +203,12 @@ Three workflows:
 - **`build.yml`** — reusable + manually dispatchable. Full Yocto build
   on an on-demand Hetzner CX43 for a single machine. Uploads the image
   artifact with 7-day retention. Used ad-hoc or called by `release.yml`.
-- **`release.yml`** — triggered on `vX.Y.Z` tag push. Calls `build.yml`
-  for **both** targets in sequence, then signs each image with
-  [cosign keyless][cosign] and publishes a GitHub Release with the
-  images, SHA256 checksums, and `.bundle` signatures attached.
+- **`release.yml`** — triggered on a timestamped tag push
+  (`YYYY.MM.DD-HH[a-z]`, see `scripts/release.sh`). Calls `build.yml`
+  for **both** targets in parallel — each has its own cache volume —
+  then signs each image with [cosign keyless][cosign] and publishes a
+  GitHub Release with the images, SHA256 checksums, and `.bundle`
+  signatures attached.
 
 [cosign]: https://docs.sigstore.dev/cosign/signing/overview/
 


### PR DESCRIPTION
## Summary
Split the single shared Hetzner cache volume into two per-target volumes so the two Yocto builds can run in parallel instead of serialized.

### Infra prerequisite (already done)
- **`oe5xrx-yocto-cache-qemux86-64`** — 30 GB, fresh.
- **`oe5xrx-yocto-cache-raspberrypi4-64`** — 30 GB, fresh.
- Old single `oe5xrx-yocto-cache` volume deleted.

### Workflow changes
- `concurrency.group`: `yocto-build` → `yocto-build-<machine>` (per-target gate).
- `CACHE_VOLUME_NAME`: `oe5xrx-yocto-cache` → `oe5xrx-yocto-cache-<machine>`.
- Builder server + runner label: `oe5xrx-yocto-builder` → `oe5xrx-yocto-builder-<machine>` (otherwise two parallel Hetzner servers collide on name; two runners collide on label).
- `release.yml`: `build-rpi.needs: build-x64` → `build-rpi.needs: preflight`. Both targets gate on preflight directly.

### Time budget
- Before: ~16 min serial (two ~6 min builds back-to-back + spin-up + publish).
- After (warm cache): ~6 min — the slower of the two concurrent builds dominates.
- **First release after merge: cold build, ~1.5 h both sides parallel.** Caches populate, back to warm after.

## Test plan
- [ ] CI green (recipe validate, lint).
- [ ] First release after merge: both builds start in parallel (create-runner jobs concurrent, not sequential).
- [ ] Both reach `Mount cache volume` — volume names match what's in Hetzner.
- [ ] Both finish; `Sign & Publish Release` picks up both artifacts.